### PR TITLE
Require Union arms to be defined statically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.0.8 - 2021-12-31
+
+### Removed
+
+- Removed `setValueFromXdr()` method from the `XdrUnion` interface. This method felt redundant from a usability perspective though it had a good technical reason to be there.
+
+### Added
+
+- Added a new static `getXdrArms` method to the `XdrUnion` interface. This will ensure that we can determine the union's value type without having to instantiate an empty class ahead of time. Going forward all union arms will have to be defined statically, which is probably for the best.
+
 ## 0.0.7 - 2021-12-18
 
 ### Added
@@ -29,7 +39,7 @@ All notable changes to `phpxdr` will be documented in this file
 
 ### Changed
 
-- Adjusted the `XdrOptional` interface to hopefully be more intuitive.  Removed references to "evaluation" in favor of "hasValue".
+- Adjusted the `XdrOptional` interface to hopefully be more intuitive. Removed references to "evaluation" in favor of "hasValue".
 
 ## 0.0.3 - 2021-11-28
 

--- a/src/Interfaces/XdrUnion.php
+++ b/src/Interfaces/XdrUnion.php
@@ -31,6 +31,13 @@ interface XdrUnion
     public static function getXdrDiscriminatorType(): string;
 
     /**
+     * Retrieve the 'arms' that have been defined in this union.
+     *
+     * @return array<int|bool|string, string>
+     */
+    public static function getXdrArms(): array;
+
+    /**
      * Retrieve the selected value to be encoded as XDR bytes.
      *
      * @return int
@@ -38,11 +45,11 @@ interface XdrUnion
     public function getXdrValue(): mixed;
 
     /**
-     * Retrieve the encoding type for the selected value.
+     * Retrieve the encoding type for a given discriminator.
      *
      * @return string
      */
-    public function getXdrValueType(): string;
+    public static function getXdrDiscriminatedValueType(int|bool|XdrEnum $discriminator): string;
 
     /**
      * If the value type requires a designated length specify it here.
@@ -55,16 +62,8 @@ interface XdrUnion
      * Create a new instance of this class from XDR.
      *
      * @param int|bool|XdrEnum $discriminator
+     * @param mixed $value
      * @return static
      */
-    public static function newFromXdr(int|bool|XdrEnum $discriminator): static;
-
-    /**
-     * Allow the XDR tool to set the value of the union.
-     *
-     * @param int|bool|XdrEnum $discriminator
-     * @param mixed $value
-     * @return void
-     */
-    public function setValueFromXdr(int|bool|XdrEnum $discriminator, mixed $value): void;
+    public static function newFromXdr(int|bool|XdrEnum $discriminator, mixed $value): static;
 }

--- a/src/Read.php
+++ b/src/Read.php
@@ -444,15 +444,10 @@ trait Read
 
         // Read the discriminator
         $discriminator = $this->read($vessel::getXdrDiscriminatorType());
+        $value = $this->read($vessel::getXdrDiscriminatedValueType($discriminator));
 
         // Instantiate the vessel
-        $vessel = $vessel::newFromXdr($discriminator);
-
-        // Decode the value and pass it to the vessel
-        $value = $this->read($vessel->getXdrValueType(), length: $vessel->getXdrValueLength());
-        $vessel->setValueFromXdr($discriminator, $value);
-
-        return $vessel;
+        return $vessel::newFromXdr($discriminator, $value);
     }
 
     /**

--- a/src/Write.php
+++ b/src/Write.php
@@ -430,15 +430,20 @@ trait Write
         }
 
         // Write the discriminator
-        $this->write($value->getXdrDiscriminator(), $value->getXdrDiscriminatorType());
+        $discriminator = $value->getXdrDiscriminator();
+        $this->write($discriminator, $value->getXdrDiscriminatorType());
 
         // Ensure a value content type has been provided
-        if (!$value->getXdrValueType()) {
+        if (!$value->getXdrDiscriminatedValueType($discriminator)) {
             throw new InvalidArgumentException('Invalid union content specified');
         }
 
         // Write the value content
-        $this->write($value->getXdrValue(), $value->getXdrValueType(), $value->getXdrValueLength());
+        $this->write(
+            $value->getXdrValue(),
+            $value->getXdrDiscriminatedValueType($discriminator),
+            $value->getXdrValueLength()
+        );
 
         return $this;
     }

--- a/tests/UnionTest.php
+++ b/tests/UnionTest.php
@@ -59,12 +59,6 @@ class ExampleUnion implements XdrUnion
 {
     const DEFAULT = 20;
 
-    protected $arms = [
-        10 => XDR::STRING,
-        20 => XDR::INT,
-        30 => XDR::FLOAT,
-    ];
-
     public function __construct(
         public ?int $selection = 20,
         public mixed $value = null
@@ -74,6 +68,15 @@ class ExampleUnion implements XdrUnion
         if ($value) {
             $this->value = $value;
         }
+    }
+
+    public static function getXdrArms(): array
+    {
+        return [
+            10 => XDR::STRING,
+            20 => XDR::INT,
+            30 => XDR::FLOAT,
+        ];
     }
 
     public function getXdrDiscriminator(): int|bool|XdrEnum
@@ -91,13 +94,13 @@ class ExampleUnion implements XdrUnion
         return $this->value;
     }
 
-    public function getXdrValueType(): string
+    public static function getXdrDiscriminatedValueType(int|bool|XdrEnum $discriminator): string
     {
-        if (array_key_exists($this->selection, array_keys($this->arms))) {
-            return $this->arms[$this->selection];
+        if ($discriminator instanceof XdrEnum) {
+            $discriminator = $discriminator->getXdrValue();
         }
 
-        return $this->arms[self::DEFAULT];
+        return self::getXdrArms()[$discriminator];
     }
 
     public function getXdrValueLength(): ?int
@@ -105,13 +108,8 @@ class ExampleUnion implements XdrUnion
         return null;
     }
 
-    public static function newFromXdr(int|bool|XdrEnum $discriminator): static
+    public static function newFromXdr(int|bool|XdrEnum $discriminator, mixed $value): static
     {
-        return new static($discriminator);
-    }
-
-    public function setValueFromXdr(int|bool|XdrEnum $discriminator, mixed $value): void
-    {
-        $this->value = $value;
+        return new static($discriminator, $value);
     }
 }


### PR DESCRIPTION
Up until now Union arms could be defined programmatically.  This is nice in theory but it required some extra legwork when decoding from XDR witch in turn required the `XdrUnion` interface to include a `setValueFromXdr()` method which turned out to be awkward when trying to understand the interface from a user's perspective.  

By defining the arms statically we can determine the value type without instantiating the interface class which simplifies things all the way around.  This is similar to the method used in [stellar/js-xdr](https://github.com/stellar/js-xdr).

Going forward all union arms will have to be defined statically.
