### PR TITLE
Require fixed lengths for union values to be defined statically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.0.9 - 2022-01-01
+
+### Changed
+
+- The previous update did not account for unions that represent fixed length values.  The `XdrUnion` interface has been altered so that fixed lengths are now also defined statically and will be looked up by discriminator.
+
 ## 0.0.8 - 2021-12-31
 
 ### Removed

--- a/src/Interfaces/XdrUnion.php
+++ b/src/Interfaces/XdrUnion.php
@@ -38,13 +38,6 @@ interface XdrUnion
     public static function getXdrArms(): array;
 
     /**
-     * Retrieve the selected value to be encoded as XDR bytes.
-     *
-     * @return int
-     */
-    public function getXdrValue(): mixed;
-
-    /**
      * Retrieve the encoding type for a given discriminator.
      *
      * @return string
@@ -56,7 +49,14 @@ interface XdrUnion
      *
      * @return int|null
      */
-    public function getXdrValueLength(): ?int;
+    public static function getXdrDiscriminatedValueLength(int|bool|XdrEnum $discriminator): ?int;
+
+    /**
+     * Retrieve the selected value to be encoded as XDR bytes.
+     *
+     * @return int
+     */
+    public function getXdrValue(): mixed;
 
     /**
      * Create a new instance of this class from XDR.

--- a/src/Read.php
+++ b/src/Read.php
@@ -442,9 +442,12 @@ trait Read
             throw new InvalidArgumentException("Class '{$vessel}' does not implement the XdrUnion interface.");
         }
 
-        // Read the discriminator
+        // Read the discriminator and the value
         $discriminator = $this->read($vessel::getXdrDiscriminatorType());
-        $value = $this->read($vessel::getXdrDiscriminatedValueType($discriminator));
+        $value = $this->read(
+            $vessel::getXdrDiscriminatedValueType($discriminator),
+            length: $vessel::getXdrDiscriminatedValueLength($discriminator)
+        );
 
         // Instantiate the vessel
         return $vessel::newFromXdr($discriminator, $value);

--- a/src/Write.php
+++ b/src/Write.php
@@ -442,7 +442,7 @@ trait Write
         $this->write(
             $value->getXdrValue(),
             $value->getXdrDiscriminatedValueType($discriminator),
-            $value->getXdrValueLength()
+            $value->getXdrDiscriminatedValueLength($discriminator)
         );
 
         return $this;

--- a/tests/UnionTest.php
+++ b/tests/UnionTest.php
@@ -13,27 +13,33 @@ class UnionTest extends TestCase
     public function it_encodes_unions()
     {
         $union = new ExampleUnion(20, 2);
-        $bytes = XDR::fresh()->write($union, XDR::UNION)->buffer();
-        $this->assertEquals(8, strlen($bytes));
-        $this->assertEquals('0000001400000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($union, XDR::UNION)->buffer();
+        $this->assertEquals('0000001400000002', bin2hex($buffer));
     }
 
     /** @test */
     public function it_encodes_unions_using_the_shorter_syntax()
     {
         $union = new ExampleUnion(20, 2);
-        $bytes = XDR::fresh()->write($union)->buffer();
-        $this->assertEquals(8, strlen($bytes));
-        $this->assertEquals('0000001400000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($union)->buffer();
+        $this->assertEquals('0000001400000002', bin2hex($buffer));
     }
 
     /** @test */
     public function it_accepts_a_union_instance_class_name_as_a_type_parameter()
     {
         $union = new ExampleUnion(20, 2);
-        $bytes = XDR::fresh()->write($union, ExampleUnion::class)->buffer();
-        $this->assertEquals(8, strlen($bytes));
-        $this->assertEquals('0000001400000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($union, ExampleUnion::class)->buffer();
+        $this->assertEquals('0000001400000002', bin2hex($buffer));
+    }
+
+    /** @test */
+    public function it_encodes_unions_that_represent_fixed_length_values()
+    {
+        $array = new ExampleArrayFixed([1, 2]);
+        $union = new ExampleUnion(30, $array);
+        $buffer = XDR::fresh()->write($union, ExampleUnion::class)->buffer();
+        $this->assertEquals('0000001e0000000100000002', bin2hex($buffer));
     }
 
     /** @test */
@@ -53,11 +59,19 @@ class UnionTest extends TestCase
         $this->assertEquals(20, $union->getXdrDiscriminator());
         $this->assertEquals(2, $union->getXdrValue());
     }
+
+    /** @test */
+    public function it_decodes_unions_that_represent_fixed_length_values()
+    {
+        $union = XDR::fromHex('0000001e0000000100000002')->read(ExampleUnion::class);
+        $this->assertInstanceOf(ExampleUnion::class, $union);
+    }
 }
 
 class ExampleUnion implements XdrUnion
 {
     const DEFAULT = 20;
+    const ARRAY_FIXED_LENGTH = 2;
 
     public function __construct(
         public ?int $selection = 20,
@@ -75,7 +89,7 @@ class ExampleUnion implements XdrUnion
         return [
             10 => XDR::STRING,
             20 => XDR::INT,
-            30 => XDR::FLOAT,
+            30 => ExampleArrayFixed::class,
         ];
     }
 
@@ -103,8 +117,12 @@ class ExampleUnion implements XdrUnion
         return self::getXdrArms()[$discriminator];
     }
 
-    public function getXdrValueLength(): ?int
+    public static function getXdrDiscriminatedValueLength(int|bool|XdrEnum $discriminator): ?int
     {
+        if (self::getXdrDiscriminatedValueType($discriminator) == XDR::ARRAY_FIXED) {
+            return self::ARRAY_FIXED_LENGTH;
+        }
+
         return null;
     }
 


### PR DESCRIPTION
When the `XdrUnion` interface was changed to require arms to be defined statically I forgot to take fixed length types into account.  This PR updates the `XdrUnion` type again to require that fixed lengths for union values also be defined statically and looked up by discriminator.