### PR TITLE
Rename XdrArray length method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.0.10 - 2022-01-03
+
+### Changed
+
+- The `getXdrFixedCount()` method in the `XdrArray` interface has been renamed to `getXdrLength()` which should hopefully be more clear.
+
 ## 0.0.9 - 2022-01-01
 
 ### Changed

--- a/src/Interfaces/XdrArray.php
+++ b/src/Interfaces/XdrArray.php
@@ -19,13 +19,13 @@ interface XdrArray
     public function getXdrArray(): array;
 
     /**
-     * If this class is modeling a fixed length array, this method defines
-     * the number of elements the array is expected to contain. This will
-     * be null for variable length arrays.
+     * If this class is modeling a fixed length array use this method
+     * to define the number of elements the array is expected to
+     * contain. This will be null for variable length arrays.
      *
      * @return integer
      */
-    public static function getXdrFixedCount(): ?int;
+    public static function getXdrLength(): ?int;
 
     /**
      * XDR arrays must be composed entirely of the same type. This method
@@ -36,8 +36,7 @@ interface XdrArray
     public static function getXdrType(): string;
 
     /**
-     * If the underlying content type requires a length it can be specified
-     * with this method.
+     * Specify the length of the underlying value type, if required.
      *
      * @return integer|null
      */

--- a/src/Read.php
+++ b/src/Read.php
@@ -38,12 +38,12 @@ trait Read
         }
 
         // Can we infer that this is a fixed length array?
-        if (class_exists($type) && $this->isInstanceOf($type, XdrArray::class) && $type::getXdrFixedCount()) {
+        if (class_exists($type) && $this->isInstanceOf($type, XdrArray::class) && $type::getXdrLength()) {
             return $this->readArrayFixed($type, $length);
         }
 
         // Can we infer that this is a variable length array?
-        if (class_exists($type) && $this->isInstanceOf($type, XdrArray::class) && !$type::getXdrFixedCount()) {
+        if (class_exists($type) && $this->isInstanceOf($type, XdrArray::class) && !$type::getXdrLength()) {
             return $this->readArrayVariable($type);
         }
 
@@ -359,7 +359,7 @@ trait Read
         }
 
         // Determine the number of elements in our fixed length array
-        $length = $length ?? $vessel::getXdrFixedCount();
+        $length = $length ?? $vessel::getXdrLength();
         if (!$length) {
             throw new InvalidArgumentException('Attempting to decode a fixed length array with no specified length');
         }

--- a/src/Write.php
+++ b/src/Write.php
@@ -38,12 +38,12 @@ trait Write
         }
 
         // Can we infer that this is a fixed array?
-        if ($value instanceof XdrArray && $value->getXdrFixedCount()) {
-            return $this->writeArrayFixed($value, $value->getXdrFixedCount());
+        if ($value instanceof XdrArray && $value->getXdrLength()) {
+            return $this->writeArrayFixed($value, $value->getXdrLength());
         }
 
         // Can we infer that this is a variable length array?
-        if ($value instanceof XdrArray && !$value->getXdrFixedCount()) {
+        if ($value instanceof XdrArray && !$value->getXdrLength()) {
             return $this->writeArrayVariable($value);
         }
 
@@ -356,7 +356,7 @@ trait Write
      */
     protected function writeArrayFixed(XdrArray $value, $length = null): self
     {
-        $count = $length ?? $value->getXdrFixedCount();
+        $count = $length ?? $value->getXdrLength();
         if (!$count) {
             throw new InvalidArgumentException('You must specify a length to encode a fixed array.');
         }

--- a/tests/ArrayFixedTest.php
+++ b/tests/ArrayFixedTest.php
@@ -64,7 +64,7 @@ class ExampleArrayFixed implements XdrArray
         return $this->arr;
     }
 
-    public static function getXdrFixedCount(): ?int
+    public static function getXdrLength(): ?int
     {
         return 2;
     }

--- a/tests/ArrayVariableTest.php
+++ b/tests/ArrayVariableTest.php
@@ -64,7 +64,7 @@ class ExampleArrayVariable implements XdrArray
         return $this->arr;
     }
 
-    public static function getXdrFixedCount(): ?int
+    public static function getXdrLength(): ?int
     {
         return null;
     }


### PR DESCRIPTION
This PR changes the name of the `getXdrFixedCount()` method in the `XdrArray` interface to `getXdrLength()`.