### PR TITLE
Fix length hangling for reading fixed length arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.0.11 - 2022-01-03
+
+### Added
+
+- Added more test coverage for the `XdrArray` interface methods.
+
+### Changed
+
+- Fixed a bug that prevented fixed length arrays from being read correctly.
+
 ## 0.0.10 - 2022-01-03
 
 ### Changed

--- a/src/Read.php
+++ b/src/Read.php
@@ -367,7 +367,7 @@ trait Read
         // Decode the array
         $arr = [];
         for ($i = 0; $i < $length; $i++) {
-            $arr[] = $this->read($vessel::getXdrType(), $vessel::getXdrTypeLength());
+            $arr[] = $this->read($vessel::getXdrType(), length: $vessel::getXdrTypeLength());
         }
 
         // Return a newly instantiated vessel class
@@ -397,7 +397,7 @@ trait Read
         // Decode the array
         $arr = [];
         for ($i = 0; $i < $count; $i++) {
-            $arr[] = $this->read($vessel::getXdrType(), $vessel::getXdrTypeLength());
+            $arr[] = $this->read($vessel::getXdrType(), length: $vessel::getXdrTypeLength());
         }
 
         // Return a newly instantiated vessel class

--- a/tests/ArrayFixedTest.php
+++ b/tests/ArrayFixedTest.php
@@ -12,27 +12,40 @@ class ArrayFixedTest extends TestCase
     public function it_encodes_fixed_length_arrays()
     {
         $arr = new ExampleArrayFixed([1, 2]);
-        $bytes = XDR::fresh()->write($arr, XDR::ARRAY_FIXED)->buffer();
-        $this->assertEquals(8, strlen($bytes));
-        $this->assertEquals('0000000100000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($arr, ExampleArrayFixed::class)->buffer();
+        $this->assertEquals('0000000100000002', bin2hex($buffer));
     }
 
     /** @test */
     public function it_accepts_a_fixed_array_instance_class_name_as_a_type_parameter()
     {
         $arr = new ExampleArrayFixed([1, 2]);
-        $bytes = XDR::fresh()->write($arr, ExampleArrayFixed::class)->buffer();
-        $this->assertEquals(8, strlen($bytes));
-        $this->assertEquals('0000000100000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($arr, ExampleArrayFixed::class)->buffer();
+        $this->assertEquals('0000000100000002', bin2hex($buffer));
     }
 
     /** @test */
     public function it_encodes_fixed_length_arrays_using_the_shorter_syntax()
     {
         $arr = new ExampleArrayFixed([1, 2]);
-        $bytes = XDR::fresh()->write($arr)->buffer();
-        $this->assertEquals(8, strlen($bytes));
-        $this->assertEquals('0000000100000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($arr)->buffer();
+        $this->assertEquals('0000000100000002', bin2hex($buffer));
+    }
+
+    /** @test */
+    public function it_encodes_fixed_length_arrays_with_values_of_different_lengths()
+    {
+        $arr = new ExampleFixedStringArray(['one', 'two', 'three']);
+        $buffer = XDR::fresh()->write($arr, ExampleFixedStringArray::class)->buffer();
+        $this->assertEquals('000000036f6e65000000000374776f00000000057468726565000000', bin2hex($buffer));
+    }
+
+    /** @test */
+    public function it_encodes_fixed_length_arrays_containing_values_with_a_fixed_length()
+    {
+        $arr = new ExampleFixedOpaqueFixedArray(['abc', 'def', 'ghi']);
+        $buffer = XDR::fresh()->write($arr, ExampleFixedOpaqueFixedArray::class)->buffer();
+        $this->assertEquals('616263006465660067686900', bin2hex($buffer));
     }
 
     /** @test */
@@ -49,6 +62,23 @@ class ArrayFixedTest extends TestCase
         $arr = XDR::fromHex('0000000300000004')->read(ExampleArrayFixed::class);
         $this->assertInstanceOf(ExampleArrayFixed::class, $arr);
         $this->assertEquals([3, 4], $arr->arr);
+    }
+
+    /** @test */
+    public function it_decodes_fixed_length_arrays_containing_values_of_different_lengths()
+    {
+        $arr = XDR::fromHex('000000036f6e65000000000374776f00000000057468726565000000')
+            ->read(ExampleFixedStringArray::class);
+        $this->assertInstanceOf(ExampleFixedStringArray::class, $arr);
+        $this->assertEquals(['one', 'two', 'three'], $arr->arr);
+    }
+
+    /** @test */
+    public function it_decodes_fixed_length_arrays_containing_values_with_a_fixed_length()
+    {
+        $arr = XDR::fromHex('616263006465660067686900')->read(ExampleFixedOpaqueFixedArray::class);
+        $this->assertInstanceOf(ExampleFixedOpaqueFixedArray::class, $arr);
+        $this->assertEquals(['abc', 'def', 'ghi'], $arr->arr);
     }
 }
 
@@ -77,6 +107,72 @@ class ExampleArrayFixed implements XdrArray
     public static function getXdrTypeLength(): ?int
     {
         return null;
+    }
+
+    public static function newFromXdr(array $arr): static
+    {
+        return new static($arr);
+    }
+}
+
+class ExampleFixedStringArray implements XdrArray
+{
+    public function __construct(public array $arr = [])
+    {
+        $this->arr = $arr;
+    }
+
+    public function getXdrArray(): array
+    {
+        return $this->arr;
+    }
+
+    public static function getXdrLength(): ?int
+    {
+        return 3;
+    }
+
+    public static function getXdrType(): string
+    {
+        return XDR::STRING;
+    }
+
+    public static function getXdrTypeLength(): ?int
+    {
+        return null;
+    }
+
+    public static function newFromXdr(array $arr): static
+    {
+        return new static($arr);
+    }
+}
+
+class ExampleFixedOpaqueFixedArray implements XdrArray
+{
+    public function __construct(public array $arr)
+    {
+        $this->arr = $arr;
+    }
+
+    public function getXdrArray(): array
+    {
+        return $this->arr;
+    }
+
+    public static function getXdrLength(): ?int
+    {
+        return 3;
+    }
+
+    public static function getXdrType(): string
+    {
+        return XDR::OPAQUE_FIXED;
+    }
+
+    public static function getXdrTypeLength(): ?int
+    {
+        return 3;
     }
 
     public static function newFromXdr(array $arr): static

--- a/tests/ArrayVariableTest.php
+++ b/tests/ArrayVariableTest.php
@@ -12,27 +12,40 @@ class ArrayVariableTest extends TestCase
     public function it_encodes_variable_length_arrays()
     {
         $arr = new ExampleArrayVariable([1, 2]);
-        $bytes = XDR::fresh()->write($arr, XDR::ARRAY_VARIABLE)->buffer();
-        $this->assertEquals(12, strlen($bytes));
-        $this->assertEquals('000000020000000100000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($arr, ExampleArrayVariable::class)->buffer();
+        $this->assertEquals('000000020000000100000002', bin2hex($buffer));
     }
 
     /** @test */
     public function it_encodes_variable_length_arrays_using_the_shorter_syntax()
     {
         $arr = new ExampleArrayVariable([1, 2]);
-        $bytes = XDR::fresh()->write($arr, XDR::ARRAY_VARIABLE)->buffer();
-        $this->assertEquals(12, strlen($bytes));
-        $this->assertEquals('000000020000000100000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($arr)->buffer();
+        $this->assertEquals('000000020000000100000002', bin2hex($buffer));
+    }
+
+    /** @test */
+    public function it_encodes_variable_length_arrays_containing_values_of_different_lengths()
+    {
+        $arr = new ExampleVariableStringArray(['one', 'two', 'three']);
+        $buffer = XDR::fresh()->write($arr, ExampleVariableStringArray::class)->buffer();
+        $this->assertEquals('00000003000000036f6e65000000000374776f00000000057468726565000000', bin2hex($buffer));
+    }
+
+    /** @test */
+    public function it_encodes_variable_length_arrays_containing_data_with_a_fixed_length()
+    {
+        $arr = new ExampleVariableOpaqueFixedArray(['abc', 'def', 'ghi']);
+        $buffer = XDR::fresh()->write($arr, ExampleVariableOpaqueFixedArray::class)->buffer();
+        $this->assertEquals('00000003616263006465660067686900',  bin2hex($buffer));
     }
 
     /** @test */
     public function it_accepts_a_variable_array_instance_class_name_as_a_type_parameter()
     {
         $arr = new ExampleArrayVariable([1, 2]);
-        $bytes = XDR::fresh()->write($arr, ExampleArrayVariable::class)->buffer();
-        $this->assertEquals(12, strlen($bytes));
-        $this->assertEquals('000000020000000100000002', bin2hex($bytes));
+        $buffer = XDR::fresh()->write($arr, ExampleArrayVariable::class)->buffer();
+        $this->assertEquals('000000020000000100000002', bin2hex($buffer));
     }
 
     /** @test */
@@ -49,6 +62,24 @@ class ArrayVariableTest extends TestCase
         $arr = XDR::fromHex('000000020000000100000002')->read(XDR::ARRAY_VARIABLE, ExampleArrayVariable::class);
         $this->assertInstanceOf(ExampleArrayVariable::class, $arr);
         $this->assertEquals([1, 2], $arr->arr);
+    }
+
+    /** @test */
+    public function it_decodes_variable_length_arrays_containing_values_of_different_lengths()
+    {
+        $arr = XDR::fromHex('00000003000000036f6e65000000000374776f00000000057468726565000000')
+            ->read(XDR::ARRAY_VARIABLE, ExampleVariableStringArray::class);
+        $this->assertInstanceOf(ExampleVariableStringArray::class, $arr);
+        $this->assertEquals(['one', 'two', 'three'], $arr->arr);
+    }
+
+    /** @test */
+    public function it_decodes_variable_length_arrays_containing_values_with_a_fixed_length()
+    {
+        $arr = XDR::fromHex('00000003616263006465660067686900')
+            ->read(XDR::ARRAY_VARIABLE, ExampleVariableOpaqueFixedArray::class);
+        $this->assertInstanceOf(ExampleVariableOpaqueFixedArray::class, $arr);
+        $this->assertEquals(['abc', 'def', 'ghi'], $arr->arr);
     }
 }
 
@@ -77,6 +108,72 @@ class ExampleArrayVariable implements XdrArray
     public static function getXdrTypeLength(): ?int
     {
         return null;
+    }
+
+    public static function newFromXdr(array $arr): static
+    {
+        return new static($arr);
+    }
+}
+
+class ExampleVariableStringArray implements XdrArray
+{
+    public function __construct(public array $arr = [])
+    {
+        $this->arr = $arr;
+    }
+
+    public function getXdrArray(): array
+    {
+        return $this->arr;
+    }
+
+    public static function getXdrLength(): ?int
+    {
+        return null;
+    }
+
+    public static function getXdrType(): string
+    {
+        return XDR::STRING;
+    }
+
+    public static function getXdrTypeLength(): ?int
+    {
+        return null;
+    }
+
+    public static function newFromXdr(array $arr): static
+    {
+        return new static($arr);
+    }
+}
+
+class ExampleVariableOpaqueFixedArray implements XdrArray
+{
+    public function __construct(public array $arr)
+    {
+        $this->arr = $arr;
+    }
+
+    public function getXdrArray(): array
+    {
+        return $this->arr;
+    }
+
+    public static function getXdrLength(): ?int
+    {
+        return null;
+    }
+
+    public static function getXdrType(): string
+    {
+        return XDR::OPAQUE_FIXED;
+    }
+
+    public static function getXdrTypeLength(): ?int
+    {
+        return 3;
     }
 
     public static function newFromXdr(array $arr): static


### PR DESCRIPTION
This PR fixes a length handling bug that was preventing fixed length arrays from being read correctly.   It also adds expanded test coverage for the `XdrArray` interface methods.