### PR TITLE
Require fixed length arrays to have a count that matches their definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.0.12 - 2022-01-04
+
+### Changed
+
+- Encoding Fixed length arrays will now throw an error exception if the array count does not exactly match the defined fixed length.
+
 ## 0.0.11 - 2022-01-03
 
 ### Added

--- a/src/Write.php
+++ b/src/Write.php
@@ -356,15 +356,17 @@ trait Write
      */
     protected function writeArrayFixed(XdrArray $value, $length = null): self
     {
-        $count = $length ?? $value->getXdrLength();
-        if (!$count) {
+        $length = $length ?? $value->getXdrLength();
+        if (!$length) {
             throw new InvalidArgumentException('You must specify a length to encode a fixed array.');
         }
 
         $arr = $value->getXdrArray();
+        $count = count($arr);
 
-        if (count($arr) > $count) {
-            throw new InvalidArgumentException('Attempting to encode an array that is longer than the specified length.');
+        if ($count != $length) {
+            $class = get_class($value);
+            throw new InvalidArgumentException("The {$class} instance requires {$length} elements but contains {$count}");
         }
 
         foreach ($arr as $child) {

--- a/tests/ArrayFixedTest.php
+++ b/tests/ArrayFixedTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use InvalidArgumentException;
 use StageRightLabs\PhpXdr\XDR;
 use PHPUnit\Framework\TestCase;
 use StageRightLabs\PhpXdr\Interfaces\XdrArray;

--- a/tests/ArrayFixedTest.php
+++ b/tests/ArrayFixedTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use InvalidArgumentException;
 use StageRightLabs\PhpXdr\XDR;
 use PHPUnit\Framework\TestCase;
 use StageRightLabs\PhpXdr\Interfaces\XdrArray;
@@ -30,6 +31,22 @@ class ArrayFixedTest extends TestCase
         $arr = new ExampleArrayFixed([1, 2]);
         $buffer = XDR::fresh()->write($arr)->buffer();
         $this->assertEquals('0000000100000002', bin2hex($buffer));
+    }
+
+    /** @test */
+    public function it_rejects_fixed_length_arrays_that_are_longer_than_the_defined_length()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $arr = new ExampleArrayFixed([1, 2, 3]);
+        XDR::fresh()->write($arr)->buffer();
+    }
+
+    /** @test */
+    public function it_rejects_fixed_length_arrays_that_are_shorter_than_the_defined_length()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $arr = new ExampleArrayFixed([1]);
+        XDR::fresh()->write($arr)->buffer();
     }
 
     /** @test */


### PR DESCRIPTION
Previously it was possible to encode a fixed length array that did not contain the same number of elements as defined in the `getXdrLength` method of the `XdrArray` interface.  This causes problems when decoding because the decoder will always pop off the defined number of elements.

This PR changes the encoder so that it rejects fixed arrays that do not match their defined length.