### PR TITLE
Alter XdrEnum interface - 'selection' instead of 'value'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.0.13 - 2022-01-24
+
+### Changed
+
+- Altered the `XdrEnum` interface: `getXdrValue` is now `getXdrSelection` And `isValidXdrValue` is now `isValidXdrSelection`.
+
 ## 0.0.12 - 2022-01-04
 
 ### Changed

--- a/src/Interfaces/XdrEnum.php
+++ b/src/Interfaces/XdrEnum.php
@@ -16,7 +16,7 @@ interface XdrEnum
      *
      * @return integer
      */
-    public function getXdrValue(): int;
+    public function getXdrSelection(): int;
 
     /**
      * Create a new instance of this class from XDR.
@@ -32,5 +32,5 @@ interface XdrEnum
      * @param integer $value
      * @return boolean
      */
-    public function isValidXdrValue(int $value): bool;
+    public function isValidXdrSelection(int $value): bool;
 }

--- a/src/Write.php
+++ b/src/Write.php
@@ -166,9 +166,9 @@ trait Write
      */
     protected function writeEnum(XdrEnum $value): self
     {
-        $int = $value->getXdrValue();
+        $int = $value->getXdrSelection();
 
-        if ($value->isValidXdrValue($int)) {
+        if ($value->isValidXdrSelection($int)) {
             return $this->writeInt($int);
         }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -49,7 +49,7 @@ class EnumTest extends TestCase
         $enum = XDR::fromHex('00000014')->read(XDR::ENUM, ExampleEnum::class);
         $this->assertInstanceOf(XdrEnum::class, $enum);
         $this->assertInstanceOf(ExampleEnum::class, $enum);
-        $this->assertEquals(ExampleEnum::BAR, $enum->getXdrValue());
+        $this->assertEquals(ExampleEnum::BAR, $enum->getXdrSelection());
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class EnumTest extends TestCase
         $enum = XDR::fromHex('00000014')->read(ExampleEnum::class);
         $this->assertInstanceOf(XdrEnum::class, $enum);
         $this->assertInstanceOf(ExampleEnum::class, $enum);
-        $this->assertEquals(ExampleEnum::BAR, $enum->getXdrValue());
+        $this->assertEquals(ExampleEnum::BAR, $enum->getXdrSelection());
     }
 
     /** @test */
@@ -80,7 +80,7 @@ class ExampleEnum implements XdrEnum
         $this->selected = $selection;
     }
 
-    public function getXdrValue(): int
+    public function getXdrSelection(): int
     {
         return $this->selected;
     }
@@ -90,7 +90,7 @@ class ExampleEnum implements XdrEnum
         return new static($value);
     }
 
-    public function isValidXdrValue(int $value): bool
+    public function isValidXdrSelection(int $value): bool
     {
         return in_array($value, [
             self::FOO,

--- a/tests/ReadTest.php
+++ b/tests/ReadTest.php
@@ -29,7 +29,7 @@ class ReadTest extends TestCase
         // enum
         $enum = $xdr->read(XDR::ENUM, ExampleEnum::class);
         $this->assertInstanceOf(ExampleEnum::class, $enum);
-        $this->assertEquals($enum->getXdrValue(), ExampleEnum::FOO);
+        $this->assertEquals($enum->getXdrSelection(), ExampleEnum::FOO);
 
         // bool
         $bool = $xdr->read(XDR::BOOL);


### PR DESCRIPTION
This PR updates the `XdrEnum` interface; favoring the word 'selection' over the word 'value' in an attempt to be a bit more explicit about what is being represented.