### PR TITLE
Fix enum usage in union test

### DIFF
--- a/tests/UnionTest.php
+++ b/tests/UnionTest.php
@@ -111,7 +111,7 @@ class ExampleUnion implements XdrUnion
     public static function getXdrDiscriminatedValueType(int|bool|XdrEnum $discriminator): string
     {
         if ($discriminator instanceof XdrEnum) {
-            $discriminator = $discriminator->getXdrValue();
+            $discriminator = $discriminator->getXdrSelection();
         }
 
         return self::getXdrArms()[$discriminator];


### PR DESCRIPTION
This PR fixes an enum reference in the `UnionTest` class.