### PR TITLE
Add convenience method for returning raw bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.0.15 - 2022-06-01
+
+## Added
+
+- Added a `toBytes()` convenience method for returning buffer contents as a string of raw bytes.
+
+## Changed
+
+- Adjusted interface class doc-blocks: 'Retrieve' is now 'Return'
+
 ## 0.0.14 - 2022-01-31
 
 ## Added

--- a/src/Interfaces/XdrEnum.php
+++ b/src/Interfaces/XdrEnum.php
@@ -12,7 +12,7 @@ namespace StageRightLabs\PhpXdr\Interfaces;
 interface XdrEnum
 {
     /**
-     * Retrieve the value to be encoded as XDR bytes.
+     * Return the value to be encoded as XDR bytes.
      *
      * @return integer
      */

--- a/src/Interfaces/XdrOptional.php
+++ b/src/Interfaces/XdrOptional.php
@@ -19,14 +19,14 @@ interface XdrOptional
     public function hasValueForXdr(): bool;
 
     /**
-     * Retrieve the selected value to be encoded as XDR bytes.
+     * Return the selected value to be encoded as XDR bytes.
      *
      * @return integer
      */
     public function getXdrValue(): mixed;
 
     /**
-     * Retrieve the desired encoding type for the selected value, specified
+     * Return the desired encoding type for the selected value, specified
      * using the XDR type constants.
      *
      * @return string

--- a/src/Interfaces/XdrUnion.php
+++ b/src/Interfaces/XdrUnion.php
@@ -15,7 +15,7 @@ use StageRightLabs\PhpXdr\Interfaces\XdrEnum;
 interface XdrUnion
 {
     /**
-     * Retrieve the discriminator value.
+     * Return the discriminator value.
      *
      * @return int
      */
@@ -31,14 +31,14 @@ interface XdrUnion
     public static function getXdrDiscriminatorType(): string;
 
     /**
-     * Retrieve the 'arms' that have been defined in this union.
+     * Return the 'arms' that have been defined in this union.
      *
      * @return array<int|bool|string, string>
      */
     public static function getXdrArms(): array;
 
     /**
-     * Retrieve the encoding type for a given discriminator.
+     * Return the encoding type for a given discriminator.
      *
      * @return string
      */
@@ -52,7 +52,7 @@ interface XdrUnion
     public static function getXdrDiscriminatedValueLength(int|bool|XdrEnum $discriminator): ?int;
 
     /**
-     * Retrieve the selected value to be encoded as XDR bytes.
+     * Return the selected value to be encoded as XDR bytes.
      *
      * @return int
      */

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -145,7 +145,7 @@ trait Utility
     }
 
     /**
-     * Retrieve the first element of an array or throw an exception.
+     * Return the first element of an array or throw an exception.
      *
      * @param mixed[]|bool|null $arr
      * @param string $message
@@ -167,7 +167,7 @@ trait Utility
     }
 
     /**
-     * Retrieve the content of the buffer.
+     * Return the buffer.
      *
      * @return string
      */
@@ -187,7 +187,7 @@ trait Utility
     }
 
     /**
-     * Retrieve the current length of the buffer.
+     * Return the current length of the buffer.
      *
      * @return integer
      */

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -145,6 +145,16 @@ trait Utility
     }
 
     /**
+     * Return the buffer as a string of raw bytes.
+     *
+     * @return string
+     */
+    public function toBytes(): string
+    {
+        return $this->buffer();
+    }
+
+    /**
      * Return the first element of an array or throw an exception.
      *
      * @param mixed[]|bool|null $arr


### PR DESCRIPTION
This PR adds a helper method `toBytes()` for returning buffer contents as a string of raw bytes.  Technically this was already possible via the `buffer()` method, but this change should make the API more understandable.