### PR TITLE
Streamline the XdrUnion interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `phpxdr` will be documented in this file
 
+## 0.01.00 - 2023-11-09
+
+- Breaking change: altered the `XdrUnion` interface; hopefully it is now easier to understand and use.
+
 ## 0.0.15 - 2022-06-01
 
 ## Added

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     },
     "scripts": {
         "format": "php-cs-fixer fix src --rules=@PSR12",
-        "phpstan": "phpstan analyse -l 9 src"
+        "phpstan": "phpstan analyse -l 9 src",
+        "test": "vendor/bin/phpunit"
     },
     "config": {
         "sort-packages": true

--- a/src/Interfaces/XdrArray.php
+++ b/src/Interfaces/XdrArray.php
@@ -43,7 +43,7 @@ interface XdrArray
     public static function getXdrTypeLength(): ?int;
 
     /**
-     * Create a new instance of this class from XDR.
+     * Allow the XDR reader to create a new instance of this class.
      *
      * @param mixed[] $arr
      * @return static

--- a/src/Interfaces/XdrEnum.php
+++ b/src/Interfaces/XdrEnum.php
@@ -19,7 +19,7 @@ interface XdrEnum
     public function getXdrSelection(): int;
 
     /**
-     * Create a new instance of this class from XDR.
+     * Allow the XDR reader to create a new instance of this class.
      *
      * @param int $value
      * @return static

--- a/src/Interfaces/XdrOptional.php
+++ b/src/Interfaces/XdrOptional.php
@@ -41,7 +41,7 @@ interface XdrOptional
     public static function getXdrValueLength(): ?int;
 
     /**
-     * Create a new instance of this class from XDR.
+     * Allow the XDR reader to create a new instance of this class.
      *
      * @param bool $hasValue
      * @param mixed $value

--- a/src/Interfaces/XdrStruct.php
+++ b/src/Interfaces/XdrStruct.php
@@ -21,8 +21,8 @@ interface XdrStruct
     public function toXdr(XDR &$xdr): void;
 
     /**
-     * Create a new instance of this class from XDR. The implementing class
-     * is responsible for decoding bytes using the provided $xdr instance.
+     * Allow the XDR reader to create a new instance of this class.
+     * The implementing class must hydrate itself by reading bytes from $xdr.
      *
      * @param XDR $xdr
      * @return static

--- a/src/Interfaces/XdrTypedef.php
+++ b/src/Interfaces/XdrTypedef.php
@@ -22,7 +22,7 @@ interface XdrTypedef
     public function toXdr(XDR &$xdr): void;
 
     /**
-     * Create a new instance of this class by reading from XDR.
+     * Allow the XDR reader to create a new instance of this class.
      *
      * @param XDR $xdr
      * @return static

--- a/src/Interfaces/XdrUnion.php
+++ b/src/Interfaces/XdrUnion.php
@@ -15,13 +15,6 @@ use StageRightLabs\PhpXdr\Interfaces\XdrEnum;
 interface XdrUnion
 {
     /**
-     * Return the discriminator value.
-     *
-     * @return int
-     */
-    public function getXdrDiscriminator(): int|bool|XdrEnum;
-
-    /**
      * What type of discriminator is being used in this union?
      * Allowed types are XDR::INT, XDR::UINT, XDR::BOOL or
      * the name of a class that implements XdrEnum.
@@ -31,25 +24,25 @@ interface XdrUnion
     public static function getXdrDiscriminatorType(): string;
 
     /**
-     * Return the 'arms' that have been defined in this union.
+     * Return the discriminator value.
      *
-     * @return array<int|bool|string, string>
+     * @return int
      */
-    public static function getXdrArms(): array;
+    public function getXdrDiscriminator(): int|bool|XdrEnum;
 
     /**
      * Return the encoding type for a given discriminator.
      *
      * @return string
      */
-    public static function getXdrDiscriminatedValueType(int|bool|XdrEnum $discriminator): string;
+    public static function getXdrType(int|bool|XdrEnum $discriminator): string;
 
     /**
      * If the value type requires a designated length specify it here.
      *
      * @return int|null
      */
-    public static function getXdrDiscriminatedValueLength(int|bool|XdrEnum $discriminator): ?int;
+    public static function getXdrLength(int|bool|XdrEnum $discriminator): ?int;
 
     /**
      * Return the selected value to be encoded as XDR bytes.
@@ -59,7 +52,7 @@ interface XdrUnion
     public function getXdrValue(): mixed;
 
     /**
-     * Create a new instance of this class from XDR.
+     * Allow the XDR reader to create a new instance of this class.
      *
      * @param int|bool|XdrEnum $discriminator
      * @param mixed $value

--- a/src/Read.php
+++ b/src/Read.php
@@ -445,8 +445,8 @@ trait Read
         // Read the discriminator and the value
         $discriminator = $this->read($vessel::getXdrDiscriminatorType());
         $value = $this->read(
-            $vessel::getXdrDiscriminatedValueType($discriminator),
-            length: $vessel::getXdrDiscriminatedValueLength($discriminator)
+            $vessel::getXdrType($discriminator),
+            length: $vessel::getXdrLength($discriminator)
         );
 
         // Instantiate the vessel

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -101,7 +101,7 @@ trait Utility
     }
 
     /**
-     * Is a given named class not an instance of a given named interface?
+     * Is a named class not an instance of a given interface?
      *
      * The opposite of 'isInstanceOf()'.
      *

--- a/src/XDR.php
+++ b/src/XDR.php
@@ -44,6 +44,8 @@ final class XDR
     public const DOUBLE_BYTE_LENGTH = 8;
 
     public const MAX_LENGTH = 4294967295; // pow(2, 32) - 1
+    public const INT_MAX = 2147483647;
+    public const INT_MIN = -2147483647;
 
     protected string $buffer = '';
     protected int $cursor = 0;


### PR DESCRIPTION
This PR updates the `XdrUnion` interface to be less verbose and more inline with the other interfaces.   The `getXdrArms` method has been removed and the other methods renamed. 

In Addition, this PR also implements a few small quality of life improvements behind the scenes. 