### PR TITLE
Remove redundant return types from interfaces

### DIFF
--- a/src/Interfaces/XdrArray.php
+++ b/src/Interfaces/XdrArray.php
@@ -22,23 +22,17 @@ interface XdrArray
      * If this class is modeling a fixed length array use this method
      * to define the number of elements the array is expected to
      * contain. This will be null for variable length arrays.
-     *
-     * @return integer
      */
     public static function getXdrLength(): ?int;
 
     /**
      * XDR arrays must be composed entirely of the same type. This method
      * specifies the type using the XDR type constants.
-     *
-     * @return string
      */
     public static function getXdrType(): string;
 
     /**
      * Specify the length of the underlying value type, if required.
-     *
-     * @return integer|null
      */
     public static function getXdrTypeLength(): ?int;
 
@@ -46,7 +40,6 @@ interface XdrArray
      * Allow the XDR reader to create a new instance of this class.
      *
      * @param mixed[] $arr
-     * @return static
      */
     public static function newFromXdr(array $arr): static;
 }

--- a/src/Interfaces/XdrEnum.php
+++ b/src/Interfaces/XdrEnum.php
@@ -13,24 +13,16 @@ interface XdrEnum
 {
     /**
      * Return the value to be encoded as XDR bytes.
-     *
-     * @return integer
      */
     public function getXdrSelection(): int;
 
     /**
      * Allow the XDR reader to create a new instance of this class.
-     *
-     * @param int $value
-     * @return static
      */
     public static function newFromXdr(int $value): static;
 
     /**
      * Determine if a value is a member of the ENUM options.
-     *
-     * @param integer $value
-     * @return boolean
      */
     public function isValidXdrSelection(int $value): bool;
 }

--- a/src/Interfaces/XdrOptional.php
+++ b/src/Interfaces/XdrOptional.php
@@ -13,39 +13,27 @@ interface XdrOptional
 {
     /**
      * Is there a value to encode?
-     *
-     * @return bool
      */
     public function hasValueForXdr(): bool;
 
     /**
      * Return the selected value to be encoded as XDR bytes.
-     *
-     * @return integer
      */
     public function getXdrValue(): mixed;
 
     /**
      * Return the desired encoding type for the selected value, specified
      * using the XDR type constants.
-     *
-     * @return string
      */
     public static function getXdrValueType(): string;
 
     /**
      * If the value type requires a designated length specify it here.
-     *
-     * @return int|null
      */
     public static function getXdrValueLength(): ?int;
 
     /**
      * Allow the XDR reader to create a new instance of this class.
-     *
-     * @param bool $hasValue
-     * @param mixed $value
-     * @return static
      */
     public static function newFromXdr(bool $hasValue, mixed $value): static;
 }

--- a/src/Interfaces/XdrStruct.php
+++ b/src/Interfaces/XdrStruct.php
@@ -15,17 +15,12 @@ interface XdrStruct
      * Return the object as an XDR string. The implementing class is responsible
      * for composing the XDR byte structure for this struct; the XDR write
      * method will apply those bytes directly to its buffer.
-     *
-     * @return void
      */
     public function toXdr(XDR &$xdr): void;
 
     /**
      * Allow the XDR reader to create a new instance of this class.
      * The implementing class must hydrate itself by reading bytes from $xdr.
-     *
-     * @param XDR $xdr
-     * @return static
      */
     public static function newFromXdr(XDR &$xdr): static;
 }

--- a/src/Interfaces/XdrTypedef.php
+++ b/src/Interfaces/XdrTypedef.php
@@ -15,17 +15,11 @@ interface XdrTypedef
 {
     /**
      * Write this object to XDR
-     *
-     * @param XDR $xdr
-     * @return void
      */
     public function toXdr(XDR &$xdr): void;
 
     /**
      * Allow the XDR reader to create a new instance of this class.
-     *
-     * @param XDR $xdr
-     * @return static
      */
     public static function newFromXdr(XDR &$xdr): static;
 }

--- a/src/Interfaces/XdrUnion.php
+++ b/src/Interfaces/XdrUnion.php
@@ -18,45 +18,31 @@ interface XdrUnion
      * What type of discriminator is being used in this union?
      * Allowed types are XDR::INT, XDR::UINT, XDR::BOOL or
      * the name of a class that implements XdrEnum.
-     *
-     * @return string
      */
     public static function getXdrDiscriminatorType(): string;
 
     /**
      * Return the discriminator value.
-     *
-     * @return int
      */
     public function getXdrDiscriminator(): int|bool|XdrEnum;
 
     /**
      * Return the encoding type for a given discriminator.
-     *
-     * @return string
      */
     public static function getXdrType(int|bool|XdrEnum $discriminator): string;
 
     /**
      * If the value type requires a designated length specify it here.
-     *
-     * @return int|null
      */
     public static function getXdrLength(int|bool|XdrEnum $discriminator): ?int;
 
     /**
      * Return the selected value to be encoded as XDR bytes.
-     *
-     * @return int
      */
     public function getXdrValue(): mixed;
 
     /**
      * Allow the XDR reader to create a new instance of this class.
-     *
-     * @param int|bool|XdrEnum $discriminator
-     * @param mixed $value
-     * @return static
      */
     public static function newFromXdr(int|bool|XdrEnum $discriminator, mixed $value): static;
 }


### PR DESCRIPTION
This PR removes type definitions from doc-blocks that are no longer required.  The few that have been kept should be helpful for static analysis.